### PR TITLE
don't process all exceptions, fixes unbound path error

### DIFF
--- a/cms_redirects/middleware.py
+++ b/cms_redirects/middleware.py
@@ -6,28 +6,28 @@ class RedirectFallbackMiddleware(object):
     def process_exception(self, request, exception):
         if isinstance(exception, http.Http404):
             path = request.get_full_path()
-        try:
-            r = CMSRedirect.objects.get(site__id__exact=settings.SITE_ID, old_path=path)
-        except CMSRedirect.DoesNotExist:
-            r = None
-        if r is None and settings.APPEND_SLASH:
-            # Try removing the trailing slash.
             try:
-                r = CMSRedirect.objects.get(site__id__exact=settings.SITE_ID,
-                    old_path=path[:path.rfind('/')]+path[path.rfind('/')+1:])
+                r = CMSRedirect.objects.get(site__id__exact=settings.SITE_ID, old_path=path)
             except CMSRedirect.DoesNotExist:
-                pass
-        if r is not None:
-            if r.page:
+                r = None
+            if r is None and settings.APPEND_SLASH:
+                # Try removing the trailing slash.
+                try:
+                    r = CMSRedirect.objects.get(site__id__exact=settings.SITE_ID,
+                        old_path=path[:path.rfind('/')]+path[path.rfind('/')+1:])
+                except CMSRedirect.DoesNotExist:
+                    pass
+            if r is not None:
+                if r.page:
+                    if r.response_code == '302':
+                        return http.HttpResponseRedirect(r.page.get_absolute_url())
+                    else:
+                        return http.HttpResponsePermanentRedirect(r.page.get_absolute_url())
+                if r.new_path == '':
+                    return http.HttpResponseGone()
                 if r.response_code == '302':
-                    return http.HttpResponseRedirect(r.page.get_absolute_url())
+                    return http.HttpResponseRedirect(r.new_path)
                 else:
-                    return http.HttpResponsePermanentRedirect(r.page.get_absolute_url())
-            if r.new_path == '':
-                return http.HttpResponseGone()
-            if r.response_code == '302':
-                return http.HttpResponseRedirect(r.new_path)
-            else:
-                return http.HttpResponsePermanentRedirect(r.new_path)
+                    return http.HttpResponsePermanentRedirect(r.new_path)
         
 


### PR DESCRIPTION
Hi, thanks for the useful app!

I noticed the middleware throws an exception on line 10 if the exception is not a 404. This is a minor patch to fix that.

Thanks,
Mike Johnson
