### PR TITLE
Lookup redirects without query string

### DIFF
--- a/cms_redirects/middleware.py
+++ b/cms_redirects/middleware.py
@@ -3,21 +3,35 @@ from cms_redirects.models import CMSRedirect
 from django import http
 from django.conf import settings
 
+def get_redirect(old_path):
+    try:
+        r = CMSRedirect.objects.get(site__id__exact=settings.SITE_ID,
+                                    old_path=old_path)
+    except CMSRedirect.DoesNotExist:
+        r = None
+    return r
+
+def remove_slash(path):
+    return path[:path.rfind('/')]+path[path.rfind('/')+1:]
+
+def remove_query(path):
+    return path.split('?', 1)[0]
+
 class RedirectFallbackMiddleware(object):
     def process_exception(self, request, exception):
         if isinstance(exception, http.Http404):
             path = request.environ.get('PATH_INFO')
-            try:
-                r = CMSRedirect.objects.get(site__id__exact=settings.SITE_ID, old_path=path)
-            except CMSRedirect.DoesNotExist:
-                r = None
+            r = get_redirect(path)
+
+            # If we couldn't find the path, try removing the slash
+            # and/or removing the query string.
             if r is None and settings.APPEND_SLASH:
-                # Try removing the trailing slash.
-                try:
-                    r = CMSRedirect.objects.get(site__id__exact=settings.SITE_ID,
-                        old_path=path[:path.rfind('/')]+path[path.rfind('/')+1:])
-                except CMSRedirect.DoesNotExist:
-                    pass
+                r = get_redirect(remove_slash(path))
+            if r is None and path.count('?'):
+                r = get_redirect(remove_query(path))
+            if r is None and path.count('?') and settings.APPEND_SLASH:
+                r = get_redirect(remove_slash(remove_query(path)))
+
             if r is not None:
                 if r.page:
                     if r.response_code == '302':
@@ -30,5 +44,3 @@ class RedirectFallbackMiddleware(object):
                     return http.HttpResponseRedirect(r.new_path)
                 else:
                     return http.HttpResponsePermanentRedirect(r.new_path)
-        
-

--- a/cms_redirects/middleware.py
+++ b/cms_redirects/middleware.py
@@ -1,3 +1,4 @@
+from urlparse import urlparse
 from cms_redirects.models import CMSRedirect
 from django import http
 from django.conf import settings
@@ -5,7 +6,7 @@ from django.conf import settings
 class RedirectFallbackMiddleware(object):
     def process_exception(self, request, exception):
         if isinstance(exception, http.Http404):
-            path = request.get_full_path()
+            path = request.environ.get('PATH_INFO')
             try:
                 r = CMSRedirect.objects.get(site__id__exact=settings.SITE_ID, old_path=path)
             except CMSRedirect.DoesNotExist:


### PR DESCRIPTION
Since we are using the PATH_INFO to look up redirects, sometimes we end up searching with query strings in the URL. Change this so that now if we fail to match with a query string in place, remove the query string and try again.

Let me know how it looks to you.

Thanks,

Mike.
