### PR TITLE
Fix broken unit tests

### DIFF
--- a/cms_redirects/admin.py
+++ b/cms_redirects/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from cms_redirects.models import CMSRedirect
 
+
 class CMSRedirectAdmin(admin.ModelAdmin):
     list_display = ('old_path', 'new_path', 'page', 'page_site', 'site', 'actual_response_code',)
     list_filter = ('site',)
@@ -8,10 +9,10 @@ class CMSRedirectAdmin(admin.ModelAdmin):
     radio_fields = {'site': admin.VERTICAL}
     fieldsets = [
         ('Source', {
-            "fields": ('site','old_path',)
+            "fields": ('site', 'old_path',)
         }),
         ('Destination', {
-            "fields": ('new_path','page', 'response_code',)
+            "fields": ('new_path', 'page', 'response_code',)
         }),
     ]
 

--- a/cms_redirects/middleware.py
+++ b/cms_redirects/middleware.py
@@ -27,29 +27,29 @@ class RedirectFallbackMiddleware(object):
 
             # First try the whole path.
             path = request.get_full_path()
-            r = get_redirect(path)
+            redirect = get_redirect(path)
 
             # It could be that we need to try without a trailing slash.
-            if r is None and settings.APPEND_SLASH:
-                r = get_redirect(remove_slash(path))
+            if redirect is None and settings.APPEND_SLASH:
+                redirect = get_redirect(remove_slash(path))
 
             # It could be that the redirect is defined without a query string.
-            if r is None and path.count('?'):
-                r = get_redirect(remove_query(path))
+            if redirect is None and path.count('?'):
+                redirect = get_redirect(remove_query(path))
 
             # It could be that we need to try without query string and without a trailing slash.
-            if r is None and path.count('?') and settings.APPEND_SLASH:
-                r = get_redirect(remove_slash(remove_query(path)))
+            if redirect is None and path.count('?') and settings.APPEND_SLASH:
+                redirect = get_redirect(remove_slash(remove_query(path)))
 
-            if r is not None:
-                if r.page:
-                    if r.response_code == '302':
-                        return http.HttpResponseRedirect(r.page.get_absolute_url())
+            if redirect is not None:
+                if redirect.page:
+                    if redirect.response_code == '302':
+                        return http.HttpResponseRedirect(redirect.page.get_absolute_url())
                     else:
-                        return http.HttpResponsePermanentRedirect(r.page.get_absolute_url())
-                if r.new_path == '':
+                        return http.HttpResponsePermanentRedirect(redirect.page.get_absolute_url())
+                if redirect.new_path == '':
                     return http.HttpResponseGone()
-                if r.response_code == '302':
-                    return http.HttpResponseRedirect(r.new_path)
+                if redirect.response_code == '302':
+                    return http.HttpResponseRedirect(redirect.new_path)
                 else:
-                    return http.HttpResponsePermanentRedirect(r.new_path)
+                    return http.HttpResponsePermanentRedirect(redirect.new_path)

--- a/cms_redirects/middleware.py
+++ b/cms_redirects/middleware.py
@@ -13,7 +13,7 @@ def get_redirect(old_path):
 
 
 def remove_slash(path):
-    return path[:path.rfind('/')]+path[path.rfind('/')+1:]
+    return path[:path.rfind('/')] + path[path.rfind('/') + 1:]
 
 
 def remove_query(path):
@@ -21,6 +21,7 @@ def remove_query(path):
 
 
 class RedirectFallbackMiddleware(object):
+
     def process_exception(self, request, exception):
         if isinstance(exception, http.Http404):
 
@@ -40,7 +41,6 @@ class RedirectFallbackMiddleware(object):
             if r is None and path.count('?') and settings.APPEND_SLASH:
                 r = get_redirect(remove_slash(remove_query(path)))
 
-
             if r is not None:
                 if r.page:
                     if r.response_code == '302':
@@ -53,5 +53,3 @@ class RedirectFallbackMiddleware(object):
                     return http.HttpResponseRedirect(r.new_path)
                 else:
                     return http.HttpResponsePermanentRedirect(r.new_path)
-
-

--- a/cms_redirects/models.py
+++ b/cms_redirects/models.py
@@ -10,33 +10,44 @@ RESPONSE_CODES = (
     ('302', '302'),
 )
 
+
 class CMSRedirect(models.Model):
-    page = PageField(verbose_name=_("page"), blank=True, null=True, help_text=_("A link to a page has priority over a text link."))
+    page = PageField(verbose_name=_("page"),
+                     blank=True,
+                     null=True,
+                     help_text=_("A link to a page has priority over a text link."))
     site = models.ForeignKey(Site)
-    old_path = models.CharField(_('redirect from'), max_length=200, db_index=True,
-        help_text=_("This should be an absolute path, excluding the domain name. Example: '/events/search/'."))
-    new_path = models.CharField(_('redirect to'), max_length=200, blank=True,
-        help_text=_("This can be either an absolute path (as above) or a full URL starting with 'http://'."))
-    response_code = models.CharField(_('response code'), max_length=3, choices=RESPONSE_CODES, default=RESPONSE_CODES[0][0],
-        help_text=_("This is the http response code returned if a destination is specified. If no destination is specified the response code will be 410."))
-    
+    old_path = models.CharField(_('redirect from'),
+                                max_length=200,
+                                db_index=True,
+                                help_text=_("This should be an absolute path, excluding the domain name. Example: '/events/search/'."))
+    new_path = models.CharField(_('redirect to'),
+                                max_length=200,
+                                blank=True,
+                                help_text=_("This can be either an absolute path (as above) or a full URL starting with 'http://'."))
+    response_code = models.CharField(_('response code'),
+                                     max_length=3,
+                                     choices=RESPONSE_CODES,
+                                     default=RESPONSE_CODES[0][0],
+                                     help_text=_("This is the http response code returned if a destination is specified. If no destination is specified the response code will be 410."))
+
     def page_site(self):
         if self.page:
             return u'%s' % self.page.site
         return u''
     page_site.short_description = "Page Site"
-    
+
     def actual_response_code(self):
         if self.page or self.new_path:
             return self.response_code
         return u'410'
     actual_response_code.short_description = "Response Code"
-    
+
     class Meta:
         verbose_name = _('CMS Redirect')
         verbose_name_plural = _('CMS Redirects')
-        unique_together=(('site', 'old_path'),)
+        unique_together = (('site', 'old_path'),)
         ordering = ('old_path',)
-    
+
     def __unicode__(self):
         return "%s ---> %s" % (self.old_path, self.new_path)

--- a/cms_redirects/tests.py
+++ b/cms_redirects/tests.py
@@ -7,7 +7,9 @@ from django.conf import settings
 from cms.models import Page, Title
 from cms_redirects.models import CMSRedirect
 
+
 class TestRedirects(unittest.TestCase):
+
     def setUp(self):
         settings.APPEND_SLASH = False
 
@@ -25,7 +27,9 @@ class TestRedirects(unittest.TestCase):
         title.save()
 
     def test_301_page_redirect(self):
-        r_301_page = CMSRedirect(site=self.site, page=self.page, old_path='/301_page.php')
+        r_301_page = CMSRedirect(site=self.site,
+                                 page=self.page,
+                                 old_path='/301_page.php')
         r_301_page.save()
 
         c = Client()
@@ -34,7 +38,10 @@ class TestRedirects(unittest.TestCase):
         self.assertEqual(r._headers['location'][1], 'http://testserver/')
 
     def test_302_page_redirect(self):
-        r_302_page = CMSRedirect(site=self.site, page=self.page, old_path='/302_page.php', response_code='302')
+        r_302_page = CMSRedirect(site=self.site,
+                                 page=self.page,
+                                 old_path='/302_page.php',
+                                 response_code='302')
         r_302_page.save()
 
         c = Client()
@@ -43,7 +50,9 @@ class TestRedirects(unittest.TestCase):
         self.assertEqual(r._headers['location'][1], 'http://testserver/')
 
     def test_301_path_redirect(self):
-        r_301_path = CMSRedirect(site=self.site, new_path='/', old_path='/301_path.php')
+        r_301_path = CMSRedirect(site=self.site,
+                                 new_path='/',
+                                 old_path='/301_path.php')
         r_301_path.save()
 
         c = Client()
@@ -52,7 +61,10 @@ class TestRedirects(unittest.TestCase):
         self.assertEqual(r._headers['location'][1], 'http://testserver/')
 
     def test_302_path_redirect(self):
-        r_302_path = CMSRedirect(site=self.site, new_path='/', old_path='/302_path.php', response_code='302')
+        r_302_path = CMSRedirect(site=self.site,
+                                 new_path='/',
+                                 old_path='/302_path.php',
+                                 response_code='302')
         r_302_path.save()
 
         c = Client()
@@ -61,7 +73,9 @@ class TestRedirects(unittest.TestCase):
         self.assertEqual(r._headers['location'][1], 'http://testserver/')
 
     def test_410_redirect(self):
-        r_410 = CMSRedirect(site=self.site, old_path='/410.php', response_code='302')
+        r_410 = CMSRedirect(site=self.site,
+                            old_path='/410.php',
+                            response_code='302')
         r_410.save()
 
         c = Client()
@@ -73,7 +87,9 @@ class TestRedirects(unittest.TestCase):
         Set up a redirect as in the generic 301 page case, but then try to get this page with
         a query string appended.  Succeed nonetheless.
         """
-        r_301_page = CMSRedirect(site=self.site, page=self.page, old_path='/301_page.php')
+        r_301_page = CMSRedirect(site=self.site,
+                                 page=self.page,
+                                 old_path='/301_page.php')
         r_301_page.save()
 
         c = Client()

--- a/cms_redirects/tests.py
+++ b/cms_redirects/tests.py
@@ -34,9 +34,9 @@ class TestRedirects(TestCase):
                                  old_path='/301_page.php')
         r_301_page.save()
 
-        r = self.client.get('/301_page.php')
-        self.assertEqual(r.status_code, 301)
-        self.assertEqual(r._headers['location'][1], 'http://testserver/')
+        response = self.client.get('/301_page.php')
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response._headers['location'][1], 'http://testserver/')
 
     def test_302_page_redirect(self):
         r_302_page = CMSRedirect(site=self.site,
@@ -45,9 +45,9 @@ class TestRedirects(TestCase):
                                  response_code='302')
         r_302_page.save()
 
-        r = self.client.get('/302_page.php')
-        self.assertEqual(r.status_code, 302)
-        self.assertEqual(r._headers['location'][1], 'http://testserver/')
+        response = self.client.get('/302_page.php')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response._headers['location'][1], 'http://testserver/')
 
     def test_301_path_redirect(self):
         r_301_path = CMSRedirect(site=self.site,
@@ -55,9 +55,9 @@ class TestRedirects(TestCase):
                                  old_path='/301_path.php')
         r_301_path.save()
 
-        r = self.client.get('/301_path.php')
-        self.assertEqual(r.status_code, 301)
-        self.assertEqual(r._headers['location'][1], 'http://testserver/')
+        response = self.client.get('/301_path.php')
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response._headers['location'][1], 'http://testserver/')
 
     def test_302_path_redirect(self):
         r_302_path = CMSRedirect(site=self.site,
@@ -66,9 +66,9 @@ class TestRedirects(TestCase):
                                  response_code='302')
         r_302_path.save()
 
-        r = self.client.get('/302_path.php')
-        self.assertEqual(r.status_code, 302)
-        self.assertEqual(r._headers['location'][1], 'http://testserver/')
+        response = self.client.get('/302_path.php')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response._headers['location'][1], 'http://testserver/')
 
     def test_410_redirect(self):
         r_410 = CMSRedirect(site=self.site,
@@ -76,8 +76,8 @@ class TestRedirects(TestCase):
                             response_code='302')
         r_410.save()
 
-        r = self.client.get('/410.php')
-        self.assertEqual(r.status_code, 410)
+        response = self.client.get('/410.php')
+        self.assertEqual(response.status_code, 410)
 
     def test_redirect_can_ignore_query_string(self):
         """
@@ -89,6 +89,6 @@ class TestRedirects(TestCase):
                                  old_path='/301_page.php')
         r_301_page.save()
 
-        r = self.client.get('/301_page.php?this=is&a=query&string')
-        self.assertEqual(r.status_code, 301)
-        self.assertEqual(r._headers['location'][1], 'http://testserver/')
+        response = self.client.get('/301_page.php?this=is&a=query&string')
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response._headers['location'][1], 'http://testserver/')


### PR DESCRIPTION
As per subject line - the unit tests had been broken by recent versions of django/django-cms, so I've got them working again.
At the same time I tidied up some of the source code to be a bit more PEP8 in style, and also removed a couple of single-letter variable names as these made it really hard to run cms-redirects through the Python debugger.
